### PR TITLE
Adding SSEmpty.unity to Build Settings only once on Windows.

### DIFF
--- a/Assets/SSSystem/Scripts/SSSceneManager.cs
+++ b/Assets/SSSystem/Scripts/SSSceneManager.cs
@@ -1929,6 +1929,7 @@ public class SSSceneManager : MonoBehaviour
         if (!Application.isPlaying)
         {
             string emptyScene = SSFile.GetPathTemplateFile("SSEmpty.unity");
+            emptyScene = emptyScene.Replace(System.IO.Path.DirectorySeparatorChar, '/');
 
             var scenes = EditorBuildSettings.scenes;
 


### PR DESCRIPTION
This fix replaces the directory separators(backslashes on Windows, forward slashes on Mac) to forward slashes in the SSEmpty.unity path to use the same separator in the Build Settings even on Windows.
